### PR TITLE
Add Tailwind config

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- add `tailwind.config.js` with default Tailwind settings for `/src`

## Testing
- `npm run lint` *(fails: `next` not found)*