### PR TITLE
Update service worker caching logic

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,93 +1,82 @@
+const CORE_CACHE = 'core-v1';
+const TILE_CACHE = 'tiles-v1';
+const ROUTE_CACHE = 'route-v1';
+const OTHER_CACHE = 'other-v1';
 
-    // Based off of https://github.com/pwa-builder/PWABuilder/blob/main/docs/sw.js
+const CORE_ASSETS = [
+  '/',
+  '/manifest.json',
+  '/next.svg',
+  '/vercel.svg',
+  '/globe.svg',
+  '/file.svg',
+  '/window.svg'
+];
 
-    /*
-      Welcome to our basic Service Worker! This Service Worker offers a basic offline experience
-      while also being easily customizeable. You can add in your own code to implement the capabilities
-      listed below, or change anything else you would like.
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CORE_CACHE).then(cache => cache.addAll(CORE_ASSETS))
+  );
+  self.skipWaiting();
+});
 
+self.addEventListener('activate', event => {
+  const allowed = [CORE_CACHE, TILE_CACHE, ROUTE_CACHE, OTHER_CACHE];
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(key => !allowed.includes(key)).map(key => caches.delete(key)))
+    )
+  );
+  self.clients.claim();
+});
 
-      Need an introduction to Service Workers? Check our docs here: https://docs.pwabuilder.com/#/home/sw-intro
-      Want to learn more about how our Service Worker generation works? Check our docs here: https://docs.pwabuilder.com/#/studio/existing-app?id=add-a-service-worker
-
-      Did you know that Service Workers offer many more capabilities than just offline? 
-        - Background Sync: https://microsoft.github.io/win-student-devs/#/30DaysOfPWA/advanced-capabilities/06
-        - Periodic Background Sync: https://web.dev/periodic-background-sync/
-        - Push Notifications: https://microsoft.github.io/win-student-devs/#/30DaysOfPWA/advanced-capabilities/07?id=push-notifications-on-the-web
-        - Badges: https://microsoft.github.io/win-student-devs/#/30DaysOfPWA/advanced-capabilities/07?id=application-badges
-    */
-
-    const HOSTNAME_WHITELIST = [
-        self.location.hostname,
-        'fonts.gstatic.com',
-        'fonts.googleapis.com',
-        'cdn.jsdelivr.net'
-    ]
-
-    // The Util Function to hack URLs of intercepted requests
-    const getFixedUrl = (req) => {
-        var now = Date.now()
-        var url = new URL(req.url)
-
-        // 1. fixed http URL
-        // Just keep syncing with location.protocol
-        // fetch(httpURL) belongs to active mixed content.
-        // And fetch(httpRequest) is not supported yet.
-        url.protocol = self.location.protocol
-
-        // 2. add query for caching-busting.
-        // Github Pages served with Cache-Control: max-age=600
-        // max-age on mutable content is error-prone, with SW life of bugs can even extend.
-        // Until cache mode of Fetch API landed, we have to workaround cache-busting with query string.
-        // Cache-Control-Bug: https://bugs.chromium.org/p/chromium/issues/detail?id=453190
-        if (url.hostname === self.location.hostname) {
-            url.search += (url.search ? '&' : '?') + 'cache-bust=' + now
+function cacheFirst(request, cacheName) {
+  return caches.open(cacheName).then(cache =>
+    cache.match(request).then(resp => {
+      if (resp) {
+        return resp;
+      }
+      return fetch(request).then(networkResp => {
+        if (networkResp && networkResp.status === 200) {
+          cache.put(request, networkResp.clone());
         }
-        return url.href
-    }
-
-    /**
-     *  @Lifecycle Activate
-     *  New one activated when old isnt being used.
-     *
-     *  waitUntil(): activating ====> activated
-     */
-    self.addEventListener('activate', event => {
-      event.waitUntil(self.clients.claim())
+        return networkResp;
+      });
     })
+  );
+}
 
-    /**
-     *  @Functional Fetch
-     *  All network requests are being intercepted here.
-     *
-     *  void respondWith(Promise<Response> r)
-     */
-    self.addEventListener('fetch', event => {
-    // Skip some of cross-origin requests, like those for Google Analytics.
-    if (HOSTNAME_WHITELIST.indexOf(new URL(event.request.url).hostname) > -1) {
-        // Stale-while-revalidate
-        // similar to HTTP's stale-while-revalidate: https://www.mnot.net/blog/2007/12/12/stale
-        // Upgrade from Jake's to Surma's: https://gist.github.com/surma/eb441223daaedf880801ad80006389f1
-        const cached = caches.match(event.request)
-        const fixedUrl = getFixedUrl(event.request)
-        const fetched = fetch(fixedUrl, { cache: 'no-store' })
-        const fetchedCopy = fetched.then(resp => resp.clone())
+function networkFirst(request, cacheName) {
+  return caches.open(cacheName).then(cache =>
+    fetch(request)
+      .then(networkResp => {
+        if (networkResp && networkResp.status === 200) {
+          cache.put(request, networkResp.clone());
+        }
+        return networkResp;
+      })
+      .catch(() => cache.match(request))
+  );
+}
 
-        // Call respondWith() with whatever we get first.
-        // If the fetch fails (e.g disconnected), wait for the cache.
-        // If there’s nothing in cache, wait for the fetch.
-        // If neither yields a response, return offline pages.
-        event.respondWith(
-        Promise.race([fetched.catch(_ => cached), cached])
-            .then(resp => resp || fetched)
-            .catch(_ => { /* eat any errors */ })
-        )
+self.addEventListener('fetch', event => {
+  const { request } = event;
+  const url = new URL(request.url);
 
-        // Update the cache with the version we fetched (only for ok status)
-        event.waitUntil(
-        Promise.all([fetchedCopy, caches.open("pwa-cache")])
-            .then(([response, cache]) => response.ok && cache.put(event.request, response))
-            .catch(_ => { /* eat any errors */ })
-        )
-    }
-    })
+  if (url.origin === location.origin) {
+    event.respondWith(cacheFirst(request, CORE_CACHE));
+    return;
+  }
+
+  if (url.hostname === 'tile.openstreetmap.org') {
+    event.respondWith(cacheFirst(request, TILE_CACHE));
+    return;
+  }
+
+  if (url.hostname === 'api.openrouteservice.org') {
+    event.respondWith(networkFirst(request, ROUTE_CACHE));
+    return;
+  }
+
+  event.respondWith(networkFirst(request, OTHER_CACHE));
+});


### PR DESCRIPTION
## Summary
- custom service worker for precaching core assets
- cache OSM tiles and OpenRouteService data
- provide network-first fallback for other requests

## Testing
- `npm run lint` *(fails: `next` not found)*